### PR TITLE
fix: The incorrect setting did not throw a prompt.

### DIFF
--- a/src/memos.ts
+++ b/src/memos.ts
@@ -51,6 +51,7 @@ class MemosSync {
     await this.choosingClient();
     if (this.memosClient === undefined || this.memosClient === null) {
       logseq.UI.showMsg("Memos Sync Setup issue", "error");
+      return
     }
     try {
       await this.sync();
@@ -142,7 +143,11 @@ class MemosSync {
   private async choosingClient() {
     const { host, openId }: any = logseq.settings;
     const client = new MemosGeneralClient(host, openId);
-    this.memosClient = await client.getClient();
+    try {
+      this.memosClient = await client.getClient();
+    } catch (error) {
+      console.error("memos-sync: get client error", error);
+    }
   }
 
   public parseSetting() {


### PR DESCRIPTION
When there is an incorrect setting, perform manual sync or automatic sync. Currently only

```
Staring Sync Memos
```

I caught the error and prompt it

<img width="475" alt="CleanShot 2023-07-24 at 22 44 26@2x" src="https://github.com/EINDEX/logseq-memos-sync/assets/44605072/33b43ae5-a117-4076-9c17-82899b28bb1c">
